### PR TITLE
Allow specifying which host patterns to trust in the constructor

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,4 +6,10 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/MessageValidator.php
+++ b/src/MessageValidator.php
@@ -18,7 +18,12 @@ class MessageValidator
     /** @var string */
     private $hostPattern;
 
-    /** @var string */
+    /**
+     * @var string  A pattern that will match all regional SNS endpoints, e.g.:
+     *                  - sns.<region>.amazonaws.com        (AWS)
+     *                  - sns.us-gov-west-1.amazonaws.com   (AWS GovCloud)
+     *                  - sns.cn-north-1.amazonaws.com.cn   (AWS China)
+     */
     private static $defaultHostPattern
         = '/^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$/';
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -42,15 +42,31 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testFactorySucceedsWithGoodData()
+    /**
+     * @dataProvider messageTypeProvider
+     *
+     * @param string $messageType
+     */
+    public function testConstructorSucceedsWithGoodData($messageType)
     {
-        $this->assertInstanceOf('Aws\Sns\Message', new Message($this->messageData));
+        $this->assertInstanceOf('Aws\Sns\Message', new Message(
+            ['Type' => $messageType] + $this->messageData
+        ));
+    }
+
+    public function messageTypeProvider()
+    {
+        return [
+            ['Notification'],
+            ['SubscriptionConfirmation'],
+            ['UnsubscribeConfirmation'],
+        ];
     }
 
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryFailsWithNoType()
+    public function testConstructorFailsWithNoType()
     {
         $data = $this->messageData;
         unset($data['Type']);
@@ -60,7 +76,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryFailsWithMissingData()
+    public function testConstructorFailsWithMissingData()
     {
         new Message(['Type' => 'Notification']);
     }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -31,6 +31,17 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testIterable()
+    {
+        $message = new Message($this->messageData);
+
+        $this->assertInstanceOf('Traversable', $message);
+        foreach ($message as $key => $value) {
+            $this->assertTrue(isset($this->messageData[$key]));
+            $this->assertEquals($value, $this->messageData[$key]);
+        }
+    }
+
     public function testFactorySucceedsWithGoodData()
     {
         $this->assertInstanceOf('Aws\Sns\Message', new Message($this->messageData));
@@ -52,6 +63,32 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testFactoryFailsWithMissingData()
     {
         new Message(['Type' => 'Notification']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRequiresTokenAndSubscribeUrlForSubscribeMessage()
+    {
+        new Message(
+            ['Type' => 'SubscriptionConfirmation'] + array_diff_key(
+                $this->messageData,
+                array_flip(['Token', 'SubscribeURL'])
+            )
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRequiresTokenAndSubscribeUrlForUnsubscribeMessage()
+    {
+        new Message(
+            ['Type' => 'UnsubscribeConfirmation'] + array_diff_key(
+                $this->messageData,
+                array_flip(['Token', 'SubscribeURL'])
+            )
+        );
     }
 
     public function testCanCreateFromRawPost()
@@ -86,5 +123,17 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'] = 'Notification';
         Message::fromRawPostData();
         unset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE']);
+    }
+
+    public function testArrayAccess()
+    {
+        $message = new Message($this->messageData);
+
+        $this->assertInstanceOf('ArrayAccess', $message);
+        $message['foo'] = 'bar';
+        $this->assertTrue(isset($message['foo']));
+        $this->assertTrue($message['foo'] === 'bar');
+        unset($message['foo']);
+        $this->assertFalse(isset($message['foo']));
     }
 }

--- a/tests/MessageValidatorTest.php
+++ b/tests/MessageValidatorTest.php
@@ -79,7 +79,7 @@ class MessageValidatorTest extends \PHPUnit_Framework_TestCase
             function () {
                 return self::$certificate;
             },
-            ['/^(foo|bar).example.com$/']
+            '/^(foo|bar).example.com$/'
         );
         $message = $this->getTestMessage([
             'SigningCertURL' => 'https://foo.example.com/baz.pem',


### PR DESCRIPTION
For use with SNS-compatible services whose signing certificates don't live on a host matching `/^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$/`.