### PR TITLE
Suggest official AWS SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
         "issues": "https://github.com/aws/aws-sns-message-validator/issues"
     },
+    "suggest": {
+        "aws/aws-sdk-php": "The official Amazon Web Services PHP SDK."
+    },
     "require": {
         "php": ">=5.4",
         "ext-openssl": "*"


### PR DESCRIPTION
Although this package does not officially _depend_ on the AWS SDK, I can’t think of a reason why you would use this _without_ the SDK, so adding the SDK package as a suggestion.