### PR TITLE
Add a factory method to Message to create from PSR-7 Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 sudo: false
+dist: trusty
 
 install:
   - travis_retry composer update --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,15 @@
         "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
         "issues": "https://github.com/aws/aws-sns-message-validator/issues"
     },
-    "suggest": {
-        "aws/aws-sdk-php": "The official Amazon Web Services PHP SDK."
-    },
     "require": {
         "php": ">=5.4",
-        "ext-openssl": "*"
+        "ext-openssl": "*",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^2.3",
+        "guzzlehttp/psr7": "^1.4"
     },
     "autoload": {
         "psr-4": { "Aws\\Sns\\": "src/" }

--- a/src/Message.php
+++ b/src/Message.php
@@ -49,10 +49,6 @@ class Message implements \ArrayAccess, \IteratorAggregate
      */
     public static function fromPsrRequest(RequestInterface $request)
     {
-        if ($request->getHeaderLine(self::MESSAGE_TYPE_HEADER) === '') {
-            throw new \RuntimeException('SNS message type header not provided.');
-        }
-
         return self::fromJsonString($request->getBody());
     }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -8,8 +8,6 @@ use Psr\Http\Message\RequestInterface;
  */
 class Message implements \ArrayAccess, \IteratorAggregate
 {
-    const MESSAGE_TYPE_HEADER = 'HTTP_X_AMZ_SNS_MESSAGE_TYPE';
-
     private static $requiredKeys = [
         'Message',
         'MessageId',
@@ -33,7 +31,7 @@ class Message implements \ArrayAccess, \IteratorAggregate
     public static function fromRawPostData()
     {
         // Make sure the SNS-provided header exists.
-        if (!isset($_SERVER[self::MESSAGE_TYPE_HEADER])) {
+        if (!isset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'])) {
             throw new \RuntimeException('SNS message type header not provided.');
         }
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -111,7 +111,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
     public function testCanCreateFromRawPost()
     {
-        $_SERVER[Message::MESSAGE_TYPE_HEADER] = 'Notification';
+        $_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'] = 'Notification';
 
         // Prep php://input with mocked data
         MockPhpStream::setStartingData(json_encode($this->messageData));
@@ -122,7 +122,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Aws\Sns\Message', $message);
 
         stream_wrapper_restore("php");
-        unset($_SERVER[Message::MESSAGE_TYPE_HEADER]);
+        unset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE']);
     }
 
     /**
@@ -138,9 +138,9 @@ class MessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateFromRawPostFailsWithMissingData()
     {
-        $_SERVER[Message::MESSAGE_TYPE_HEADER] = 'Notification';
+        $_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'] = 'Notification';
         Message::fromRawPostData();
-        unset($_SERVER[Message::MESSAGE_TYPE_HEADER]);
+        unset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE']);
     }
 
     public function testCanCreateFromPsr7Request()
@@ -148,7 +148,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $request = new Request(
             'POST',
             '/',
-            [Message::MESSAGE_TYPE_HEADER => ['foo']],
+            [],
             json_encode($this->messageData)
         );
         $message = Message::fromPsrRequest($request);
@@ -163,7 +163,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $request = new Request(
             'POST',
             '/',
-            [Message::MESSAGE_TYPE_HEADER => ['foo']],
+            [],
             'Not valid JSON'
         );
         Message::fromPsrRequest($request);

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -158,20 +158,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testCreateFromPsr7RequestFailsWithMissingHeader()
-    {
-        $request = new Request(
-            'POST',
-            '/',
-            [],
-            json_encode($this->messageData)
-        );
-        Message::fromPsrRequest($request);
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCreateFromPsr7RequestFailsWithMissingData()
     {
         $request = new Request(


### PR DESCRIPTION
Resolves #19 

This PR adds the ability to create a `Message` instance from a PSR-7 request. It also cleans up the composer.json file a bit (since this library is meant to be used independently of the AWS SDK for PHP, there's no need to suggest its installation).

/cc @kstich 