### PR TITLE
Add a Guzzle certificate client and add Guzzle 6 as a suggested dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,8 @@ dist: trusty
 install:
   - travis_retry composer update --no-interaction --prefer-dist
 
+matrix:
+  allow_failures:
+    - php: 5.4
+
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,11 @@
     "require-dev": {
         "phpunit/phpunit": "^4.0",
         "squizlabs/php_codesniffer": "^2.3",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.4",
+        "guzzlehttp/guzzle": "^6.0"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "^6.0"
     },
     "autoload": {
         "psr-4": { "Aws\\Sns\\": "src/" }

--- a/src/Exception/CertificateRetrievalException.php
+++ b/src/Exception/CertificateRetrievalException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Aws\Sns\Exception;
+
+use RuntimeException;
+
+class CertificateRetrievalException extends RuntimeException {}

--- a/src/GuzzleCertificateClient.php
+++ b/src/GuzzleCertificateClient.php
@@ -1,0 +1,41 @@
+<?php
+namespace Aws\Sns;
+
+use Aws\Sns\Exception\CertificateRetrievalException;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+
+class GuzzleCertificateClient
+{
+    private $client;
+
+    public function __construct(ClientInterface $client = null)
+    {
+        $this->client = $client ?: new Client();
+    }
+
+    public function __invoke($url)
+    {
+        try {
+            $response = $this->client->request('GET', $url);
+        } catch (RequestException $exception) {
+            throw new CertificateRetrievalException(
+                'Error encountered fetching signature verification certificate from SNS',
+                $exception->hasResponse()
+                    ? $exception->getResponse()->getStatusCode()
+                    : 0,
+                $exception
+            );
+        }
+
+        if ($response->getStatusCode() === 200) {
+            return (string) $response->getBody();
+        }
+
+        throw new CertificateRetrievalException(
+            'Error encountered fetching signature verification certificate from SNS',
+            $response->getStatusCode()
+        );
+    }
+}

--- a/tests/GuzzleCertificateClientTest.php
+++ b/tests/GuzzleCertificateClientTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace Aws\Sns;
+
+use Aws\Sns\Exception\CertificateRetrievalException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+class GuzzleCertificateClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturnsTheStringBodyOfAGuzzleResponse()
+    {
+        $client = new Client(['handler' => function () {
+            return Promise\promise_for(new Response(200, [], 'CERT'));
+        }]);
+        $certClient = new GuzzleCertificateClient($client);
+
+        $this->assertSame('CERT', $certClient('https://example.com'));
+    }
+
+    /**
+     * @expectedException \Aws\Sns\Exception\CertificateRetrievalException
+     * @expectedExceptionCode 500
+     */
+    public function testConvertsRequestExceptionToCertException()
+    {
+        $client = new Client(['handler' => function (Request $request) {
+            return Promise\rejection_for(
+                new RequestException('Not found', $request, new Response(500))
+            );
+        }]);
+        $certClient = new GuzzleCertificateClient($client);
+
+        $certClient('https://example.com');
+    }
+
+    /**
+     * @expectedException \Aws\Sns\Exception\CertificateRetrievalException
+     * @expectedExceptionCode 301
+     */
+    public function testConvertsNon200ResponseToCertException()
+    {
+        $client = new Client(['handler' => function () {
+            return Promise\promise_for(new Response(301, [
+                'Location' => 'https://www.malicious-domain.com/dont-go-here',
+            ]));
+        }]);
+        $certClient = new GuzzleCertificateClient($client);
+
+        $certClient('https://example.com');
+    }
+}


### PR DESCRIPTION
`file_get_contents` triggers errors and warnings rather than throwing exceptions, which can make recovering from a failure state tricky. This PR adds Guzzle as an optional dependency and provides a client that matches the interface expected by `Aws\Sns\MessageValidator`. Since Guzzle will also use cURL if it's available, this PR should resolve #23 

/cc @kstich 