### PR TITLE
Update README to spell out role of SubscribeURL in UnsubscribeConfirmation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ Unsubscribing looks the same as subscribing, except the message type will be
 
 ```php
 if ($message['Type'] === 'UnsubscribeConfirmation') {
-   file_get_contents($message['SubscribeURL']);
+    // Unsubscribed in error? You can resubscribe by visiting the endpoint
+    // provided as the message's SubscribeURL field.
+    file_get_contents($message['SubscribeURL']);
 }
 ```
 


### PR DESCRIPTION
The current readme gives an example in which the URL is always followed, which would make it impossible to unsubscribe an endpoint from a topic. This should resolve #22 

/cc @kstich 