### PR TITLE
Add composer test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
     },
     "autoload-dev": {
         "psr-4": { "Aws\\Sns\\": "tests/" }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }


### PR DESCRIPTION
Mini addition to run tests through composer with:
```bash
composer test
```
This is a nice default composer offers.

This avoids having to install phpunit globally or typing the path to the local `vendor/bin/phpunit`.