### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0",
+        "phpunit/phpunit": "^4.8.35",
         "squizlabs/php_codesniffer": "^2.3",
         "guzzlehttp/psr7": "^1.4"
     },

--- a/tests/FunctionalValidationsTest.php
+++ b/tests/FunctionalValidationsTest.php
@@ -2,11 +2,13 @@
 
 namespace Aws\Sns;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Aws\Sns\MessageValidator
  * @covers Aws\Sns\Message
  */
-class FunctionalValidationsTest extends \PHPUnit_Framework_TestCase
+class FunctionalValidationsTest extends TestCase
 {
     private static $certificate =
 '-----BEGIN CERTIFICATE-----

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Sns;
 
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Sns\Message
  */
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     public $messageData = array(
         'Message' => 'a',

--- a/tests/MessageValidatorTest.php
+++ b/tests/MessageValidatorTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Aws\Sns;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Aws\Sns\MessageValidator
  */
-class MessageValidatorTest extends \PHPUnit_Framework_TestCase
+class MessageValidatorTest extends TestCase
 {
     const VALID_CERT_URL = 'https://sns.foo.amazonaws.com/bar.pem';
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.