### PR TITLE
split up missing and invalid certificate errors

### DIFF
--- a/src/MessageValidator.php
+++ b/src/MessageValidator.php
@@ -86,6 +86,11 @@ class MessageValidator
         // Get the certificate.
         $this->validateUrl($message['SigningCertURL']);
         $certificate = call_user_func($this->certClient, $message['SigningCertURL']);
+        if ($certificate === false) {
+            throw new InvalidSnsMessageException(
+                "Cannot get the certificate from \"{$message['SigningCertURL']}\"."
+            );
+        }
 
         // Extract the public key.
         $key = openssl_get_publickey($certificate);

--- a/tests/MessageValidatorTest.php
+++ b/tests/MessageValidatorTest.php
@@ -90,6 +90,17 @@ class MessageValidatorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Aws\Sns\Exception\InvalidSnsMessageException
+     * @expectedExceptionMessageRegExp /Cannot get the certificate from ".+"./
+     */
+    public function testValidateFailsWhenCannotGetCertificate()
+    {
+        $validator = new MessageValidator($this->getMockHttpClient(false));
+        $message = $this->getTestMessage();
+        $validator->validate($message);
+    }
+
+    /**
+     * @expectedException \Aws\Sns\Exception\InvalidSnsMessageException
      * @expectedExceptionMessage Cannot get the public key from the certificate.
      */
     public function testValidateFailsWhenCannotDeterminePublicKey()


### PR DESCRIPTION
Adds the `false` check on the result of the certClient and accompanying test.

Resolves #32 