### PR TITLE
pin travis to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:


### PR DESCRIPTION
Pin Travis to Ubuntu Trusty, 14.04 for testing on 5.4 and 5.5.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
