### PR TITLE
Remove outdated paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ if ($validator->isValid($message)) {
 The SNS Message Validator can be installed via [Composer][].
 
     $ composer require aws/aws-php-sns-message-validator
-   
-Since the library has no other PHP dependencies, you can also easily install
-the library from the [source code][] here on GitHub, assuming you include the
-files manually or use your own autoloader.
 
 ## About Amazon SNS
 


### PR DESCRIPTION
*Issue #, if available:*

none.

*Description of changes:*

The standalone installation (without composer) paragraph was written in 2015, when the library indeed had zero dependencies.

It does have a dependency now, on `psr/http-message` (introduced in 2017), so this paragraph is outdated and should probably be removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
