### PR TITLE
Make Message::fromJsonString() public

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -61,7 +61,7 @@ class Message implements \ArrayAccess, \IteratorAggregate
      * @param string $requestBody
      * @return Message
      */
-    private static function fromJsonString($requestBody)
+    public static function fromJsonString($requestBody)
     {
         $data = json_decode($requestBody, true);
         if (JSON_ERROR_NONE !== json_last_error() || !is_array($data)) {


### PR DESCRIPTION
*Issue #, if available:*

none

---

*Description of changes:*

As far as I can see, there is no reason why `Message::fromJsonString()` cannot be public, as it does not break encapsulation, does not expose internal data, and does not expect any prior validation of input.

**Why is it useful?**

If you're using Symfony, you usually want to keep things well encapsulated and testable, so you don't want to use `Message::fromRawPostData()`, but you'd rather get the JSON body from the Symfony's `Request` object.

So we're off to `Message::fromPsrRequest()`. Oh wait, **Symfony's Request does not implement PSR-7**, so we have to use a [bridge](https://symfony.com/doc/current/components/psr7.html), additional dependencies, and more boilerplate code to convert the Symfony Request to a PSR-7 Request.

Whereas if you just make this method public, we can do it directly with Symfony's `Request` object, using a one-liner:

```php
$message = Message::fromJsonString($request->getContent());
```

This is a simple, non-breaking change, would you be OK to merge it and tag a release?

Thank you!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
