### PR TITLE
Mute warning when file_get_contents() fails

### DIFF
--- a/src/MessageValidator.php
+++ b/src/MessageValidator.php
@@ -57,14 +57,16 @@ class MessageValidator
      *
      * @param callable $certClient Callable used to download the certificate.
      *                             Should have the following function signature:
-     *                             `function (string $certUrl) : string $certContent`
+     *                             `function (string $certUrl) : string|false $certContent`
      * @param string $hostNamePattern
      */
     public function __construct(
         callable $certClient = null,
         $hostNamePattern = ''
     ) {
-        $this->certClient = $certClient ?: 'file_get_contents';
+        $this->certClient = $certClient ?: function($certUrl) {
+            return @ file_get_contents($certUrl);
+        };
         $this->hostPattern = $hostNamePattern ?: self::$defaultHostPattern;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

none.

*Description of the issue:*

Currently, the library uses `file_get_contents()` by default to retrieve the `SigningCertURL`. It assumes that this function just returns `false` when it fails. But it actually also issues a warning, for example:

> Warning:  file_get_contents(): php_network_getaddresses: getaddrinfo failed: Name or service not known

This is an issue when you have configured an error handler to convert all warnings to exceptions (for example, in Symfony when using `framework.php_errors.throw`), in which case you get an uncaught erorr exception instead of an `InvalidSnsMessageException`, as [this code](https://github.com/aws/aws-php-sns-message-validator/blob/master/src/MessageValidator.php#L89-L93) can never be reached.

*Description of changes:*

This PR does two things:

- Replace `file_get_contents()` with a closure that prepends the mute operator `@` to the function; so the function will always return a `string` or `false` as expected, but never trigger a warning
- Clarify the `$certClient` callable return type, which is [expected](https://github.com/aws/aws-php-sns-message-validator/blob/master/src/MessageValidator.php#L89) to return `string|false`, not just `string`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
