### PR TITLE
psr/http-message is not required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "ext-openssl": "*",
-        "psr/http-message": "^1.0"
+        "ext-openssl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",


### PR DESCRIPTION
## Issue

The package [`psr/http-message`](https://packagist.org/packages/psr/http-message) is installed even if it's not used. The class `Psr\Http\Message\RequestInterface` don't have to exist to be used as argument type of an optional method.
https://github.com/aws/aws-php-sns-message-validator/blob/97501cf382af53818161c156a8af07c073889577/src/Message.php#L53-L56

## Description of changes

Remove the dependency. It will continue to be installed on projects that require implementations (tests uses `guzzlehttp/psr7`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
