### PR TITLE
Avoid deprecation notices in PHP 8.1

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -92,26 +92,31 @@ class Message implements \ArrayAccess, \IteratorAggregate
         $this->data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->data[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return isset($this->data[$key]) ? $this->data[$key] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->data[$key] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->data[$key]);


### PR DESCRIPTION
Solves #54 for now in a backwards compatible way, as the `#[\ReturnTypeWillChange]` are comments in any versions before PHP8 and attributes in PHP8+.

Return types still should be added before PHP9, but when doing that it would make sense to add types to all classes and release a new major version with a target of PHP 7.4+ or even 8.0+.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
