### PR TITLE
Update MessageValidator.php

### DIFF
--- a/src/MessageValidator.php
+++ b/src/MessageValidator.php
@@ -96,7 +96,8 @@ class MessageValidator
         }
 
         // Extract the public key.
-        $key = openssl_get_publickey($certificate);
+        $certificateContent = file_get_contents($certificate);
+        $key = openssl_get_publickey($certificateContent);
         if (!$key) {
             throw new InvalidSnsMessageException(
                 'Cannot get the public key from the certificate.'


### PR DESCRIPTION
Updated MessageValidator.php public key extraction method . on PHP 8.1.18 (cli) openssl_get_publickey OR (openssl_pkey_get_public) didn't read the file content from url and i don't know why exactly . i changed my ini to allow_url_fopen=on but nothing changed .

*Issue #, if available:*

*Description of changes:*
added file_get_contents before openssl_get_publickey and pass the content to openssl_get_publickey.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
