### PR TITLE
chore: changes to meet php>=7.2.5 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,16 @@
         "issues": "https://github.com/aws/aws-sns-message-validator/issues"
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.2.5",
         "ext-openssl": "*",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0",
+        "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
         "squizlabs/php_codesniffer": "^2.3",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+        "yoast/phpunit-polyfills": "^1.0"
+
     },
     "autoload": {
         "psr-4": { "Aws\\Sns\\": "src/" }

--- a/tests/FunctionalValidationsTest.php
+++ b/tests/FunctionalValidationsTest.php
@@ -2,11 +2,13 @@
 
 namespace Aws\Sns;
 
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
 /**
  * @covers Aws\Sns\MessageValidator
  * @covers Aws\Sns\Message
  */
-class FunctionalValidationsTest extends \PHPUnit_Framework_TestCase
+class FunctionalValidationsTest extends TestCase
 {
     private static $certificate =
 '-----BEGIN CERTIFICATE-----

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Sns;
 
 use GuzzleHttp\Psr7\Request;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * @covers \Aws\Sns\Message
  */
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     public $messageData = array(
         'Message' => 'a',
@@ -25,7 +26,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testGetters()
     {
         $message = new Message($this->messageData);
-        $this->assertInternalType('array', $message->toArray());
+        $this->assertIsArray($message->toArray());
 
         foreach ($this->messageData as $key => $expectedValue) {
             $this->assertTrue(isset($message[$key]));
@@ -65,29 +66,23 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorFailsWithNoType()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $data = $this->messageData;
         unset($data['Type']);
         new Message($data);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorFailsWithMissingData()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Message(['Type' => 'Notification']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRequiresTokenAndSubscribeUrlForSubscribeMessage()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Message(
             ['Type' => 'SubscriptionConfirmation'] + array_diff_key(
                 $this->messageData,
@@ -96,11 +91,9 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRequiresTokenAndSubscribeUrlForUnsubscribeMessage()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Message(
             ['Type' => 'UnsubscribeConfirmation'] + array_diff_key(
                 $this->messageData,
@@ -125,19 +118,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         unset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCreateFromRawPostFailsWithMissingHeader()
     {
+        $this->expectException(\RuntimeException::class);
         Message::fromRawPostData();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCreateFromRawPostFailsWithMissingData()
     {
+        $this->expectException(\RuntimeException::class);
         $_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'] = 'Notification';
         Message::fromRawPostData();
         unset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE']);
@@ -155,11 +144,9 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Aws\Sns\Message', $message);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCreateFromPsr7RequestFailsWithMissingData()
     {
+        $this->expectException(\RuntimeException::class);
         $request = new Request(
             'POST',
             '/',


### PR DESCRIPTION
*Description of changes:*
Since we are deprecating php<7.2.5 some code changes are done here, due to that a bump for some dependencies is also done in this commit. One example is with phpunit 9, which requires that test units extends from PHPUnit\Framework\TestCas and no from \PHPUnit_Framework_TestCase. Another example is that the annotations @expectedException, @expectedExceptionMessage, @expectedExceptionMessageRegExp, among others, are deprecated in phpunit 9, and instead the code had to be refactored to use the recommended function for each annotation, such as instead of @expectedException we need to use expectException(exceptionClassName), etc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
