### PR TITLE
Instantiate message via late static binding

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -30,7 +30,7 @@ class Message implements \ArrayAccess, \IteratorAggregate
     /**
      * Creates a Message object from the raw POST data
      *
-     * @return Message
+     * @return static
      * @throws \RuntimeException If the POST data is absent, or not a valid JSON document
      */
     public static function fromRawPostData()
@@ -41,25 +41,25 @@ class Message implements \ArrayAccess, \IteratorAggregate
         }
 
         // Read the raw POST data and JSON-decode it into a message.
-        return self::fromJsonString(file_get_contents('php://input'));
+        return static::fromJsonString(file_get_contents('php://input'));
     }
 
     /**
      * Creates a Message object from a PSR-7 Request or ServerRequest object.
      *
      * @param RequestInterface $request
-     * @return Message
+     * @return static
      */
     public static function fromPsrRequest(RequestInterface $request)
     {
-        return self::fromJsonString($request->getBody());
+        return static::fromJsonString($request->getBody());
     }
 
     /**
      * Creates a Message object from a JSON-decodable string.
      *
      * @param string $requestBody
-     * @return Message
+     * @return static
      */
     public static function fromJsonString($requestBody)
     {
@@ -68,7 +68,7 @@ class Message implements \ArrayAccess, \IteratorAggregate
             throw new \RuntimeException('Invalid POST data.');
         }
 
-        return new Message($data);
+        return new static($data);
     }
 
     /**


### PR DESCRIPTION
Currently the `Message` class uses instantiation via its class name. The class isn't final, so extending it is possible.
A use case demonstrating the issue:

```php
<?php

namespace App\Http\Controllers\Webhooks;

use Aws\Sns\Message;

/**
 * These annotation are added so that we enforce the right return type.
 * @method static self fromRawPostData()
 * @method static self fromPsrRequest()
 */
final class SnsMessage extends Message
{
    public function isSubscriptionConfirmation(): bool
    {
        return $this['Type'] === SnsNotificationType::SubscriptionConfirmation->value;
    }

    public function isNotification(): bool
    {
        return $this['Type'] === SnsNotificationType::Notification->value;
    }

    // We override the method so the correct type is returned.
    // PHP doesn't support upcasting, so using static in non-final classes would make it so much easier.
    #[\Override]
    public static function fromJsonString($requestBody): self
    {
        $baseMessage = parent::fromJsonString($requestBody);

        return new self($baseMessage->toArray());
    }
}
```

The class above adds some helper methods, but also has to redefine `fromJsonString` to specify the right class to instantiate.
With this change overriding `fromJsonString` and adding the class annotations isn't required, reducing the boilerplate a lot.

Another option would be making the `Message` class final.
