### PR TITLE
chore: Modified bug issue template to add checkbox to report potential regression.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -12,6 +12,14 @@ body:
       description: What is the problem? A clear and concise description of the bug.
     validations:
       required: true
+  - type: checkboxes
+    id: regression
+    attributes:
+      label: Regression Issue
+      description: What is a regression? If it worked in a previous version but doesn't in the latest version, it's considered a regression. In this case, please provide specific version number in the report.
+      options:
+        - label: Select this option if this issue appears to be a regression.
+          required: false
   - type: textarea
     id: expected
     attributes:

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -1,0 +1,32 @@
+# Apply potential regression label on issues
+name: issue-regression-label
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  add-regression-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - name: Fetch template body
+      id: check_regression
+      uses: actions/github-script@v7
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TEMPLATE_BODY: ${{ github.event.issue.body }}
+      with:
+        script: |
+          const regressionPattern = /\[x\] Select this option if this issue appears to be a regression\./i;
+          const template = `${process.env.TEMPLATE_BODY}`
+          const match = regressionPattern.test(template);
+          core.setOutput('is_regression', match);
+    - name: Manage regression label
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
+          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        else
+          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+        fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Modified bug issue template to add checkbox to report potential regression.
- Added GitHub action to add/remove label `potential-regression` when issue is created/edited.

**NOTE:**
- The GitHub action code was ported from CDK repo.
- The label `potential-regression` would need to be created manually (we could use color `#FF6700` and description `Marking this issue as a potential regression to be checked by team member` to make it consistent across SDK repos)

Label `potential-regression` would make issue standout in the list and help engineers to **triage** potential high severity issues effectively.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
