### PR TITLE
Fix PHP 8.4 deprecation: Implicitly marking parameter

### DIFF
--- a/src/MessageValidator.php
+++ b/src/MessageValidator.php
@@ -62,7 +62,7 @@ class MessageValidator
      * @param string $hostNamePattern
      */
     public function __construct(
-        callable $certClient = null,
+        ?callable $certClient = null,
         $hostNamePattern = ''
     ) {
         $this->certClient = $certClient ?: function($certUrl) {


### PR DESCRIPTION
*Description of changes:*

Starting in PHP 8.4, you must explicitly mark parameters as nullable. Since the explicit nullable type has been available since PHP 7.1, this should work in all the versions supported by this project (>=7.2.5).

Link: [Fix PHP 8.4 deprecation: Implicitly marking parameters as nullable is deprecated](https://dev.to/gromnan/fix-php-84-deprecation-implicitly-marking-parameter-as-nullable-is-deprecated-the-explicit-nullable-type-must-be-used-instead-5gp3)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
