### PR TITLE
Implicitly marking parameter $certClient as nullable is deprecated

### DIFF
--- a/src/MessageValidator.php
+++ b/src/MessageValidator.php
@@ -62,7 +62,7 @@ class MessageValidator
      * @param string $hostNamePattern
      */
     public function __construct(
-        callable $certClient = null,
+        ?callable $certClient = null,
         $hostNamePattern = ''
     ) {
         $this->certClient = $certClient ?: function($certUrl) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
