### PR TITLE
chore: drop <8.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
     name: Run tests on PHP ${{ matrix.php-versions }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "issues": "https://github.com/aws/aws-sns-message-validator/issues"
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "ext-openssl": "*",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
         "squizlabs/php_codesniffer": "^2.3",
-        "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+        "guzzlehttp/psr7": "^2.4.5",
         "yoast/phpunit-polyfills": "^1.0"
 
     },


### PR DESCRIPTION
*Description of changes:*
Drops support for PHP runtimes 8.0.x and below to align with the SDK's runtime support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
